### PR TITLE
Fixed epel dependency from Ansible Galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -103,7 +103,7 @@ galaxy_info:
   #- system
   #- web
 dependencies:
-  - Rackspace_Automation.epel
+  - rack-roles.epel
   # List your role dependencies here, one per line. Only
   # dependencies available via galaxy should be listed here.
   # Be sure to remove the '[]' above if you add dependencies


### PR DESCRIPTION
The `epel` dependency has been published to the Ansible Galaxy as `rack-roles.epel`.
https://galaxy.ansible.com/rack-roles/epel/